### PR TITLE
Fix issue 16: Fix submit and search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ backups/
 config.yaml
 dist/
 pyproject.toml
+.vscode/

--- a/butlarr/services/__init__.py
+++ b/butlarr/services/__init__.py
@@ -72,11 +72,6 @@ class ArrService(TelegramHandler):
         elif action == Action.DELETE:
             r = self._delete(endpoint, params)
 
-        print(endpoint)
-        print(params)
-        print(r)
-        print(r.content)
-
         if not r:
             return fallback
 

--- a/butlarr/services/__init__.py
+++ b/butlarr/services/__init__.py
@@ -21,6 +21,7 @@ def find_first(elems, check, fallback=0):
 class Action(Enum):
     GET = "get"
     POST = "post"
+    PUT = "put"
     DELETE = "delete"
 
 
@@ -44,6 +45,11 @@ class ArrService(TelegramHandler):
         return requests.post(
             f"{self.api_url}/{endpoint}", params={"apikey": self.api_key}, json=params
         )
+    
+    def _put(self, endpoint, params={}):
+        return requests.put(
+            f"{self.api_url}/{endpoint}", params={"apikey": self.api_key}, json=params
+        )
 
     def _get(self, endpoint, params={}):
         return requests.get(
@@ -61,8 +67,15 @@ class ArrService(TelegramHandler):
             r = self._get(endpoint, params)
         elif action == Action.POST:
             r = self._post(endpoint, params)
+        elif action == Action.PUT:
+            r = self._put(endpoint, params)
         elif action == Action.DELETE:
             r = self._delete(endpoint, params)
+
+        print(endpoint)
+        print(params)
+        print(r)
+        print(r.content)
 
         if not r:
             return fallback
@@ -160,9 +173,17 @@ class ArrService(TelegramHandler):
     ):
         assert item, "Missing required arg! You need to provide a item!"
 
+        item_id = item.get('id')
+        if item_id:
+            action = Action.PUT
+            endpoint = f'{self.arr_variant.value}/{item_id}'
+        else:
+            action = Action.POST
+            endpoint = self.arr_variant.value
+
         return self.request(
-            self.arr_variant.value,
-            action=Action.POST,
+            endpoint,
+            action=action,
             params={
                 **item,
                 "qualityProfileId": quality_profile_id,

--- a/butlarr/services/radarr.py
+++ b/butlarr/services/radarr.py
@@ -174,7 +174,7 @@ class Radarr(ExtArrService, ArrService):
                     rows_action.append(
                         [
                             Button(f"🗑 Remove", self.get_clbk("remove")),
-                            Button(f"✅ Submit", self.get_clbk("add", "no-search")),
+                            Button(f"🔍 Search", self.get_clbk("add", "search")),
                         ]
                     )
         else:
@@ -362,7 +362,8 @@ class Radarr(ExtArrService, ArrService):
         if not result:
             return Response(caption="Seems like something went wrong...")
 
-        return Response(caption="Movie added!")
+        return Response(caption="Movie updated!" if state.items[state.index].get("id")
+                                    else "Movie added!")
 
     @clear
     @callback(cmds=["cancel"])

--- a/butlarr/services/radarr.py
+++ b/butlarr/services/radarr.py
@@ -174,7 +174,12 @@ class Radarr(ExtArrService, ArrService):
                     rows_action.append(
                         [
                             Button(f"🗑 Remove", self.get_clbk("remove")),
-                            Button(f"🔍 Search", self.get_clbk("add", "search")),
+                            Button(f"✅ Submit", self.get_clbk("add", "no-search")),
+                        ]
+                    )
+                    rows_action.append(
+                        [
+                            Button(f"✅ + 🔍 Submit & Search", self.get_clbk("add", "search")),
                         ]
                     )
         else:

--- a/butlarr/services/sonarr.py
+++ b/butlarr/services/sonarr.py
@@ -198,7 +198,7 @@ class Sonarr(ExtArrService, ArrService):
                     rows_action.append(
                         [
                             Button(f"🗑 Remove", self.get_clbk("remove")),
-                            Button(f"✅ Submit", self.get_clbk("add", "no-search")),
+                            Button(f"🔍 Search", self.get_clbk("add", "search")),
                         ]
                     )
         else:
@@ -413,7 +413,8 @@ class Sonarr(ExtArrService, ArrService):
         if not result:
             return Response(caption="Seems like something went wrong...")
 
-        return Response(caption="Series added!")
+        return Response(caption="Series updated!" if state.items[state.index].get("id") 
+                                    else "Series added!")
 
     @clear
     @callback(cmds=["cancel"])

--- a/butlarr/services/sonarr.py
+++ b/butlarr/services/sonarr.py
@@ -198,7 +198,12 @@ class Sonarr(ExtArrService, ArrService):
                     rows_action.append(
                         [
                             Button(f"🗑 Remove", self.get_clbk("remove")),
-                            Button(f"🔍 Search", self.get_clbk("add", "search")),
+                            Button(f"✅ Submit", self.get_clbk("add", "no-search")),
+                        ]
+                    )
+                    rows_action.append(
+                        [
+                            Button(f"✅ + 🔍 Submit & Search", self.get_clbk("add", "search")),
                         ]
                     )
         else:


### PR DESCRIPTION
Fix for [Issue 16](https://github.com/TrimVis/butlarr/issues/16)

Now when searching a movie or series that is already in the library, butlarr will send a PUT request with move or series ID in the url.

![image](https://github.com/TrimVis/butlarr/assets/14909817/7d38d798-8aa3-42cd-9fb2-6016cc88345d)
![image](https://github.com/TrimVis/butlarr/assets/14909817/2c3a7641-63e9-4cf4-b88a-4e3b1a2aa948)
